### PR TITLE
mac OS用のパスの設定を追加

### DIFF
--- a/mtcsync/mpvex.py
+++ b/mtcsync/mpvex.py
@@ -2,7 +2,12 @@ import os
 
 basepath: str = os.path.dirname(os.path.abspath(__file__))
 dllspath: str = os.path.join(basepath, "lib")
-os.environ["PATH"] = dllspath + os.pathsep + os.environ["PATH"]
+
+if os.name == "nt":
+    os.environ["PATH"] = dllspath + os.pathsep + os.environ.get("PATH", "")
+else:
+    os.environ["DYLD_LIBRARY_PATH"] = dllspath + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
+
 
 import mpv
 


### PR DESCRIPTION
mac OSではctypesでDYLD_LIBRARY_PATHを探索しているのでWindowsとmac OSでパスの設定先の変更をしました
合わせて環境変数にパスがまだ存在しない場合にエラーが発生していたので修正しました