### PR TITLE
timecodeのインストールに失敗するため暫定対応

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = "^3.12"
 mido = "^1.3.2"
 python-rtmidi = "^1.5.8"
-timecode = "^1.3.1"
+timecode = "<1.3.2"
 questionary = "^2.0.1"
 mpv = "^1.0.5"
 


### PR DESCRIPTION
poetry installでtimecodeのインストールに失敗してしまうのでtimecodeのバージョンを1.3.1以下になるように暫定的に対応しています