### PR TITLE
動画再生後にウィンドウを閉じず、最後の表示のまま維持されるように

### DIFF
--- a/mtcsync/mtcsync.py
+++ b/mtcsync/mtcsync.py
@@ -73,7 +73,7 @@ player: mpvex.MPVEX = mpvex.MPVEX(
     input_builtin_bindings=False,
     pause=True,
     idle=True,
-    keep_on= "yes"
+    keep_on=True
 )
 
 player.loadlist(os.path.expanduser(answers["m3u_path"]))

--- a/mtcsync/mtcsync.py
+++ b/mtcsync/mtcsync.py
@@ -72,7 +72,8 @@ player: mpvex.MPVEX = mpvex.MPVEX(
     config="yes",
     input_builtin_bindings=False,
     pause=True,
-    idle=True
+    idle=True,
+    keep_on= "yes"
 )
 
 player.loadlist(os.path.expanduser(answers["m3u_path"]))

--- a/mtcsync/mtcsync.py
+++ b/mtcsync/mtcsync.py
@@ -73,7 +73,7 @@ player: mpvex.MPVEX = mpvex.MPVEX(
     input_builtin_bindings=False,
     pause=True,
     idle=True,
-    keep_on=True
+    keep_open=True
 )
 
 player.loadlist(os.path.expanduser(answers["m3u_path"]))


### PR DESCRIPTION
最終フレームかどうか、m3u8取り込みの場合は最終の動画のみの挙動か確認が必要